### PR TITLE
pkp/pkp-lib#4904 fix usage stats

### DIFF
--- a/UsageStatsLoader.inc.php
+++ b/UsageStatsLoader.inc.php
@@ -171,7 +171,7 @@ class UsageStatsLoader extends FileLoader {
 
 			list($assocType, $contextPaths, $page, $op, $args) = $this->_getUrlMatches($entryData['url'], $filePath, $lineNumber);
 			if ($assocType && $contextPaths && $page && $op) {
-				list($assocId, $assocType) = $this->getAssoc($assocType, $contextPaths, $page, $op, $args);
+				list($assocId, $assocType, $representationId) = $this->getAssoc($assocType, $contextPaths, $page, $op, $args);
 			} else {
 				$assocId = $assocType = null;
 			}
@@ -221,7 +221,7 @@ class UsageStatsLoader extends FileLoader {
 			}
 
 			$lastInsertedEntries[$entryHash] = $entryData['date'];
-			$statsDao->insert($assocType, $assocId, $day, $entryData['date'], $countryCode, $region, $cityName, $type, $loadId);
+			$statsDao->insert($assocType, $assocId, $representationId, $day, $entryData['date'], $countryCode, $region, $cityName, $type, $loadId);
 		}
 
 		fclose($fhandle);
@@ -410,18 +410,31 @@ class UsageStatsLoader extends FileLoader {
 	 * @param $page string
 	 * @param $op string
 	 * @param $args array
-	 * @return array (assocId, assocType)
+	 * @return array (assocId, assocType, representationId)
 	 */
 	protected function getAssoc($assocType, $contextPaths, $page, $op, $args) {
-		$assocId = $assocTypeToReturn = null;
+		$assocId = $assocTypeToReturn = $representationId = null;
 		switch ($assocType) {
 			case ASSOC_TYPE_SUBMISSION:
+				$publicationId = null;
 				if (!isset($args[0])) break;
+				// If the operation is 'view' and the arguments count > 1
+				// the arguments must be: $submissionId/version/$publicationId.
+				// Else, it is not considered hier, as submission abstract count.
+				if ($op == 'view' && count($args) > 1) {
+					if ($args[1] !== 'version') break;
+					else if (count($args) != 3) break;
+					$publicationId = (int) $args[2];
+				}
 				$submissionId = $args[0];
 				$submissionDao = DAORegistry::getDAO('SubmissionDAO'); /* @var $submissionDao SubmissionDAO */
-				$submission = $submissionDao->getById($submissionId);
-				if ($submission) {
-					$assocId = $submission->getId();
+				$submissionExists = $submissionDao->exists($submissionId);
+				if ($submissionExists) {
+					if ($publicationId) {
+						$publication = Services::get('publication')->get($publicationId);
+						if (!$publication) break;
+					}
+					$assocId = $submissionId;
 					$assocTypeToReturn = $assocType;
 				}
 				break;
@@ -442,17 +455,17 @@ class UsageStatsLoader extends FileLoader {
 			$applicationName = $application->getName();
 			switch ($applicationName) {
 				case 'ojs2':
-					list($assocId, $assocTypeToReturn) = $this->getOJSAssoc($assocType, $contextPaths, $page, $op, $args);
+					list($assocId, $assocTypeToReturn, $representationId) = $this->getOJSAssoc($assocType, $contextPaths, $page, $op, $args);
 					break;
 				case 'omp':
-					list($assocId, $assocTypeToReturn) = $this->getOMPAssoc($assocType, $contextPaths, $page, $op, $args);
+					list($assocId, $assocTypeToReturn, $representationId) = $this->getOMPAssoc($assocType, $contextPaths, $page, $op, $args);
 					break;
 				case 'ops':
-					list($assocId, $assocTypeToReturn) = $this->getOPSAssoc($assocType, $contextPaths, $page, $op, $args);
+					list($assocId, $assocTypeToReturn, $representationId) = $this->getOPSAssoc($assocType, $contextPaths, $page, $op, $args);
 					break;
 			}
 		}
-		return array($assocId, $assocTypeToReturn);
+		return array($assocId, $assocTypeToReturn, $representationId);
 	}
 
 	/**
@@ -463,17 +476,20 @@ class UsageStatsLoader extends FileLoader {
 	 * @param $page string
 	 * @param $op string
 	 * @param $args array
-	 * @return array (assocId, assocType)
+	 * @return array (assocId, assocType, representationId)
 	 */
 	protected function getOJSAssoc($assocType, $contextPaths, $page, $op, $args) {
-		$assocId = $assocTypeToReturn = null;
+		$assocId = $assocTypeToReturn = $representationId = null;
 		switch ($assocType) {
 			case ASSOC_TYPE_SUBMISSION_FILE:
 				if (!isset($args[0])) break;
 				$submissionId = $args[0];
 				$submissionDao = DAORegistry::getDAO('SubmissionDAO'); /* @var $submissionDao SubmissionDAO */
-				$article = $submissionDao->getById($submissionId);
-				if (!$article) break;
+				$submissionExists = $submissionDao->exists($submissionId);
+				if (!$submissionExists) break;
+
+				if (!isset($args[1])) break;
+				$representationId = $args[1];
 
 				if (!isset($args[2])) break;
 				$fileId = $args[2];
@@ -523,7 +539,7 @@ class UsageStatsLoader extends FileLoader {
 				}
 				break;
 		}
-		return array($assocId, $assocTypeToReturn);
+		return array($assocId, $assocTypeToReturn, $representationId);
 	}
 
 	/**
@@ -532,15 +548,20 @@ class UsageStatsLoader extends FileLoader {
 	* @param $page string
 	* @param $op string
 	* @param $args array
-	* @return array (assocId, assocType)
+	* @return array (assocId, assocType, representationId)
 	*/
 	protected function getOMPAssoc($assocType, $contextPaths, $page, $op, $args) {
-		$assocId = $assocTypeToReturn = null;
+		$assocId = $assocTypeToReturn = $representationId = null;
 		switch ($assocType) {
 			case ASSOC_TYPE_SUBMISSION_FILE:
 				if (!isset($args[0])) break;
-				$submission = Services::get('submission')->get($args[0]);
-				if (!$submission) break;
+				$submissionId = $args[0];
+				$submissionDao = DAORegistry::getDAO('SubmissionDAO'); /* @var $submissionDao SubmissionDAO */
+				$submissionExists = $submissionDao->exists($submissionId);
+				if (!$submissionExists) break;
+
+				if (!isset($args[1])) break;
+				$representationId = $args[1];
 
 				if (!isset($args[2])) break;
 				$fileId = $args[2];
@@ -568,7 +589,7 @@ class UsageStatsLoader extends FileLoader {
 				break;
 		}
 
-		return array($assocId, $assocTypeToReturn);
+		return array($assocId, $assocTypeToReturn, $representationId);
 	}
 
 	/**
@@ -579,17 +600,20 @@ class UsageStatsLoader extends FileLoader {
 	 * @param $page string
 	 * @param $op string
 	 * @param $args array
-	 * @return array (assocId, assocType)
+	 * @return array (assocId, assocType, representationId)
 	 */
 	protected function getOPSAssoc($assocType, $contextPaths, $page, $op, $args) {
-		$assocId = $assocTypeToReturn = null;
+		$assocId = $assocTypeToReturn = $representationId = null;
 		switch ($assocType) {
 			case ASSOC_TYPE_SUBMISSION_FILE:
 				if (!isset($args[0])) break;
 				$submissionId = $args[0];
-				$submissionDao = DAORegistry::getDAO('SubmissionDAO');
-				$article = $submissionDao->getById($submissionId);
-				if (!$article) break;
+				$submissionDao = DAORegistry::getDAO('SubmissionDAO'); /* @var $submissionDao SubmissionDAO */
+				$submissionExists = $submissionDao->exists($submissionId);
+				if (!$submissionExists) break;
+
+				if (!isset($args[1])) break;
+				$representationId = $args[1];
 
 				if (!isset($args[2])) break;
 				$fileId = $args[2];
@@ -608,7 +632,7 @@ class UsageStatsLoader extends FileLoader {
 				}
 				break;
 		}
-		return array($assocId, $assocTypeToReturn);
+		return array($assocId, $assocTypeToReturn, $representationId);
 	}
 
 	/**

--- a/UsageStatsLoader.inc.php
+++ b/UsageStatsLoader.inc.php
@@ -431,8 +431,9 @@ class UsageStatsLoader extends FileLoader {
 				$submissionExists = $submissionDao->exists($submissionId);
 				if ($submissionExists) {
 					if ($publicationId) {
-						$publication = Services::get('publication')->get($publicationId);
-						if (!$publication) break;
+						$publicationDao = DAORegistry::getDAO('PublicationDAO'); /* @var $publicationDao PublicationDAO */
+						$publicationExists = $publicationDao->exists($publicationId, $submissionId);
+						if (!$publicationExists) break;
 					}
 					$assocId = $submissionId;
 					$assocTypeToReturn = $assocType;

--- a/UsageStatsMigration.inc.php
+++ b/UsageStatsMigration.inc.php
@@ -26,6 +26,7 @@ class UsageStatsMigration extends Migration {
 		Capsule::schema()->create('usage_stats_temporary_records', function (Blueprint $table) {
 			$table->bigInteger('assoc_id');
 			$table->bigInteger('assoc_type');
+			$table->bigInteger('representation_id')->nullable()->default(NULL);
 			$table->bigInteger('day');
 			$table->bigInteger('entry_time');
 			$table->bigInteger('metric')->default(1);

--- a/UsageStatsTemporaryRecordDAO.inc.php
+++ b/UsageStatsTemporaryRecordDAO.inc.php
@@ -36,6 +36,7 @@ class UsageStatsTemporaryRecordDAO extends DAO {
 	 * Add the passed usage statistic record.
 	 * @param $assocType int
 	 * @param $assocId int
+	 * @param $representationId int
 	 * @param $day string
 	 * @param $time int
 	 * @param $countryCode string
@@ -45,15 +46,16 @@ class UsageStatsTemporaryRecordDAO extends DAO {
 	 * @param $loadId string
 	 * @return boolean
 	 */
-	function insert($assocType, $assocId, $day, $time, $countryCode, $region, $cityName, $fileType, $loadId) {
+	function insert($assocType, $assocId, $representationId, $day, $time, $countryCode, $region, $cityName, $fileType, $loadId) {
 		$this->update(
 			'INSERT INTO usage_stats_temporary_records
-				(assoc_type, assoc_id, day, entry_time, country_id, region, city, file_type, load_id)
+				(assoc_type, assoc_id, representation_id, day, entry_time, country_id, region, city, file_type, load_id)
 				VALUES
-				(?, ?, ?, ?, ?, ?, ?, ?, ?)',
+				(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
 			[
 				(int) $assocType,
 				(int) $assocId,
+				isset($representationId) ? (int) $representationId : NULL,
 				$day,
 				(int) $time,
 				$countryCode,
@@ -116,9 +118,9 @@ class UsageStatsTemporaryRecordDAO extends DAO {
 	*/
 	function _getGrouped($loadId) {
 		return $this->retrieve(
-			'SELECT assoc_type, assoc_id, day, country_id, region, city, file_type, load_id, count(metric) as metric
+			'SELECT assoc_type, assoc_id, representation_id, day, country_id, region, city, file_type, load_id, count(metric) as metric
 			FROM usage_stats_temporary_records WHERE load_id = ?
-			GROUP BY assoc_type, assoc_id, day, country_id, region, city, file_type, load_id',
+			GROUP BY assoc_type, assoc_id, representation_id, day, country_id, region, city, file_type, load_id',
 			[$loadId] // $loadId is not a number.
 		);
 	}


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/4904
and this comment for what the PRs are solving: https://github.com/pkp/pkp-lib/issues/4904#issuecomment-784346753

How is to be ensured that the new structure (new column `representation_id`) of the DB table `usage_stats_temporary_records` is applied for the user after this changes are merged?